### PR TITLE
Integrate FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails', '~> 6.0.0.rc1'
+  gem 'factory_bot_rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,11 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     erubi (1.10.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.10.0)
@@ -209,6 +214,7 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   debug
+  factory_bot_rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :author do
+        name { "J.R.R Tolkien" }
+        age { 55 }
+    end
+end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+    factory :book do
+        title { "The factory book title" }
+        genre { "The factory book genre" }
+        num_pages { 100 }
+        author { FactoryBot.create(:author) }
+    end
+end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -4,4 +4,13 @@ RSpec.describe Author, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
   end
+
+  describe 'factory-bot' do
+    let!(:factory_author) { FactoryBot.create(:author) }
+
+    it 'should create a valid author' do
+      expect(factory_author.name).to eq("J.R.R Tolkien")
+      expect(factory_author.age).to eq(55)
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -5,6 +5,18 @@ RSpec.describe Book, type: :model do
     it { should belong_to(:author).class_name('Author') }
   end
 
+  describe 'factory-bot' do
+    let!(:factory_book) { FactoryBot.create(:book) }
+
+    it 'should create a valid book' do
+      expect(factory_book.title).to eq("The factory book title")
+      expect(factory_book.genre).to eq("The factory book genre")
+      expect(factory_book.num_pages).to eq(100)
+      expect(factory_book.author.name).to eq("J.R.R Tolkien")
+      expect(factory_book.author.age).to eq(55)
+    end
+  end
+
   describe 'validations' do
     let(:author) { Author.new(name: "John Doe") }
     subject { described_class.new(title: "Title", genre: "Genre", num_pages: 10, author: author) }


### PR DESCRIPTION
First, we need to install the factory bot gem in the Gemfile: `gem 'factory_bot_rails'`. It should go under the _development_ and _test_ groups.

After that is done, we create the factory file for each model we have under the `spec/factories` folder.

Finally, we test the behaviour in the model spec files.